### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+ 
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_script:
   - composer self-update
   - composer install --dev --prefer-source
 
-script: vendor/bin/phpunit  
+script: vendor/bin/phpunit


### PR DESCRIPTION
* Add PHP 7.1 and 7.2 to the Travis CI matrix
* Travis CI doesn't support PHP 5.3 on Trusty, so we use Precise image for this PHP version
  see: https://docs.travis-ci.com/user/reference/trusty#PHP-images