### PR TITLE
Remove location header when performing Turbolinks response

### DIFF
--- a/Tests/TurbolinksTest.php
+++ b/Tests/TurbolinksTest.php
@@ -42,7 +42,6 @@ class TurbolinksTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($response->headers->has('Turbolinks-Location'));
         $this->assertResponseHasNoCookies($response);
-
     }
 
     public function testDoesNothingWhenNoOriginRequestHeader()

--- a/Turbolinks.php
+++ b/Turbolinks.php
@@ -230,6 +230,7 @@ class Turbolinks
      */
     private function performTurbolinksResponse(Request $request, Response $response, $body)
     {
+        $response->headers->remove('Location');
         $response->headers->set('Content-Type', $request->getMimeType('js'));
         $response->setStatusCode(200);
         $response->setContent($body);


### PR DESCRIPTION
This PR explicitly removes the `Location` header. As it seems that my browser (Firefox) still thinks it's an actual redirect when this header is set on the response.