### PR TITLE
PHP 8.0 support and Laravel 6, 7 and 8 support 🚀

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,11 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
- 
-matrix:
-  include:
-    - php: 5.3
-      dist: precise
+  - 7.3
+  - 7.4
+  - 8.0snapshot
 
 before_script:
   - composer self-update

--- a/Tests/EventListener/TurbolinksListenerTest.php
+++ b/Tests/EventListener/TurbolinksListenerTest.php
@@ -27,13 +27,13 @@ class TurbolinksListenerTest extends TestCase
 
     private $kernel;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = new EventDispatcher();
         $this->kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->dispatcher = null;
         $this->kernel = null;

--- a/Tests/TurbolinksTest.php
+++ b/Tests/TurbolinksTest.php
@@ -24,12 +24,12 @@ class TurbolinksTest extends TestCase
      */
     private $turbolinks;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->turbolinks = new Turbolinks();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->turbolinks = null;
     }

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
-        "symfony/http-foundation": "^5.0"
+        "php": "^7.1||^8.0",
+        "symfony/http-foundation": "^4.3.4||^5.0"
     },
     "require-dev": {
-        "symfony/http-kernel": "^5.0",
-        "phpunit/phpunit": "^7.0"
+        "symfony/http-kernel": "^4.3.4||^5.0",
+        "phpunit/phpunit": "^7.5.15||^8.4||^9.3.3"
     },
     "suggest": {
         "symfony/http-kernel": "Required for usage with the Symfony HttpKernel Component"


### PR DESCRIPTION
* Drop PHP 7.0 support, [end of life](https://php.net/supported-versions.php) since the 1 Jan 2019
* Symfony HTTP Kernel 4.3 is needed for Laravel 6 _(which is the current [LTS version](https://laravel.com/docs/8.x/releases#support-policy))_
* Fix PHPUnit to use version >= 7.5